### PR TITLE
Redesign marketplace to match VoiceOS brand

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,26 +4,26 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>VoiceOS Integrations — Marketplace</title>
+<link rel="icon" type="image/jpeg" href="https://pbs.twimg.com/profile_images/2009508952007225344/CZCYftXi_400x400.jpg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Syne:wght@400;600;700;800&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
 <style>
   :root {
-    --bg: #0a0a0f;
-    --surface: #111118;
-    --surface2: #16161f;
-    --border: #1e1e2e;
-    --border2: #2a2a3d;
-    --accent: #7c6aff;
-    --accent2: #a78bfa;
-    --accent3: #c4b5fd;
-    --green: #4ade80;
-    --cyan: #22d3ee;
-    --orange: #fb923c;
-    --pink: #f472b6;
-    --text: #e2e8f0;
-    --text2: #94a3b8;
-    --text3: #475569;
-    --glow: rgba(124, 106, 255, 0.15);
+    --bg: #F9F9F9;
+    --surface: #ffffff;
+    --surface2: #f3f3f3;
+    --border: #e5e5e5;
+    --border2: #ccc;
+    --accent: #007AFF;
+    --accent2: #0358F7;
+    --accent3: #1e3a8a;
+    --green: #059669;
+    --cyan: #2563eb;
+    --orange: #d97706;
+    --pink: #db2777;
+    --text: #0a0a0a;
+    --text2: #666;
+    --text3: #999;
   }
 
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -33,22 +33,9 @@
   body {
     background: var(--bg);
     color: var(--text);
-    font-family: 'Syne', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', system-ui, sans-serif;
     min-height: 100vh;
     overflow-x: hidden;
-  }
-
-  /* ── GRID TEXTURE ── */
-  body::before {
-    content: '';
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(rgba(124,106,255,0.03) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(124,106,255,0.03) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
   }
 
   /* ── NAV ── */
@@ -57,34 +44,41 @@
     top: 0;
     z-index: 100;
     border-bottom: 1px solid var(--border);
-    background: rgba(10, 10, 15, 0.85);
+    background: rgba(249, 249, 249, 0.85);
     backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
     padding: 0 2rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    height: 60px;
+    height: 56px;
   }
 
   .nav-logo {
     display: flex;
     align-items: center;
     gap: 10px;
-    font-weight: 800;
-    font-size: 1rem;
-    letter-spacing: 0.05em;
+    font-weight: 700;
+    font-size: 0.95rem;
+    letter-spacing: -0.01em;
     text-decoration: none;
     color: var(--text);
   }
 
+  .nav-logo img {
+    height: 26px;
+    width: auto;
+    display: block;
+  }
+
   .nav-logo .badge {
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.6rem;
-    background: var(--accent);
+    background: var(--text);
     color: white;
     padding: 2px 7px;
-    border-radius: 3px;
-    letter-spacing: 0.1em;
+    border-radius: 4px;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
   }
 
@@ -99,27 +93,28 @@
     color: var(--text2);
     text-decoration: none;
     font-size: 0.85rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
+    font-weight: 500;
     transition: color 0.2s;
   }
 
   .nav-links a:hover { color: var(--text); }
 
   .nav-cta {
-    background: var(--accent);
+    background: var(--text);
     color: white !important;
     padding: 7px 16px;
-    border-radius: 6px;
-    transition: background 0.2s !important;
+    border-radius: 10px;
+    font-size: 0.82rem !important;
+    font-weight: 600 !important;
+    transition: opacity 0.2s !important;
   }
-  .nav-cta:hover { background: var(--accent2) !important; color: white !important; }
+  .nav-cta:hover { opacity: 0.8 !important; color: white !important; }
 
   /* ── HERO ── */
   .hero {
     position: relative;
     z-index: 1;
-    padding: 6rem 2rem 4rem;
+    padding: 5rem 2rem 3.5rem;
     text-align: center;
     max-width: 900px;
     margin: 0 auto;
@@ -129,16 +124,17 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.7rem;
-    color: var(--accent3);
-    border: 1px solid var(--border2);
+    color: var(--text2);
+    border: 1px solid var(--border);
     padding: 6px 14px;
     border-radius: 100px;
     margin-bottom: 2rem;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
-    background: rgba(124,106,255,0.08);
+    background: var(--surface);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
 
   .hero-tag .dot {
@@ -150,29 +146,34 @@
 
   @keyframes pulse {
     0%, 100% { opacity: 1; transform: scale(1); }
-    50% { opacity: 0.5; transform: scale(0.7); }
+    50% { opacity: 0.4; transform: scale(0.7); }
   }
 
   .hero h1 {
-    font-size: clamp(2.8rem, 7vw, 5rem);
-    font-weight: 800;
-    line-height: 1.05;
+    font-size: clamp(2.4rem, 6vw, 3.5rem);
+    font-weight: 700;
+    line-height: 1.1;
     letter-spacing: -0.03em;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.25rem;
+    color: var(--text);
   }
 
   .hero h1 span {
-    background: linear-gradient(135deg, var(--accent) 0%, var(--cyan) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--accent);
+  }
+
+  .hero-logo {
+    display: block;
+    margin: 0 auto 1.5rem;
+    height: 36px;
+    width: auto;
   }
 
   .hero p {
-    font-size: 1.15rem;
+    font-size: 1.1rem;
     color: var(--text2);
-    max-width: 560px;
-    margin: 0 auto 3rem;
+    max-width: 520px;
+    margin: 0 auto 2.5rem;
     line-height: 1.7;
     font-weight: 400;
   }
@@ -190,25 +191,26 @@
   }
 
   .stat-num {
-    font-size: 1.8rem;
-    font-weight: 800;
+    font-size: 1.6rem;
+    font-weight: 700;
     color: var(--text);
     display: block;
+    letter-spacing: -0.02em;
   }
 
   .stat-label {
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.65rem;
     color: var(--text3);
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.08em;
     margin-top: 2px;
   }
 
   .stat-divider {
     width: 1px;
-    height: 40px;
-    background: var(--border2);
+    height: 36px;
+    background: var(--border);
   }
 
   /* ── FILTERS ── */
@@ -247,43 +249,45 @@
     width: 100%;
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: 10px;
     color: var(--text);
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.8rem;
     padding: 10px 14px 10px 40px;
     outline: none;
-    transition: border-color 0.2s;
+    transition: border-color 0.2s, box-shadow 0.2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
 
   .search-input::placeholder { color: var(--text3); }
-  .search-input:focus { border-color: var(--accent); }
+  .search-input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(0,122,255,0.1); }
 
   .filter-tabs {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4rem;
     flex-wrap: wrap;
   }
 
   .filter-tab {
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.7rem;
     padding: 8px 14px;
-    border-radius: 6px;
+    border-radius: 10px;
     border: 1px solid var(--border);
-    background: transparent;
-    color: var(--text2);
+    background: var(--surface);
+    color: var(--text3);
     cursor: pointer;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.03em;
     text-transform: uppercase;
     transition: all 0.2s;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
 
-  .filter-tab:hover { border-color: var(--border2); color: var(--text); }
-  .filter-tab.active { background: var(--accent); border-color: var(--accent); color: white; }
+  .filter-tab:hover { border-color: var(--border2); color: var(--text2); }
+  .filter-tab.active { background: var(--text); border-color: var(--text); color: white; }
 
   .filter-count {
-    margin-left: 5px;
+    margin-left: 4px;
     opacity: 0.6;
   }
 
@@ -291,7 +295,7 @@
   .marketplace {
     position: relative;
     z-index: 1;
-    padding: 0 2rem 6rem;
+    padding: 0 2rem 4rem;
     max-width: 1200px;
     margin: 0 auto;
   }
@@ -299,48 +303,39 @@
   .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-    gap: 1.5rem;
+    gap: 1.25rem;
   }
 
   /* ── CARD ── */
   .card {
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 14px;
-    padding: 1.75rem;
+    border-radius: 16px;
+    padding: 1.5rem;
     position: relative;
     overflow: hidden;
-    transition: border-color 0.25s, transform 0.25s, box-shadow 0.25s;
+    transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
     cursor: pointer;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-  }
-
-  .card::before {
-    content: '';
-    position: absolute;
-    top: 0; left: 0; right: 0;
-    height: 2px;
-    background: linear-gradient(90deg, var(--accent), var(--cyan));
-    opacity: 0;
-    transition: opacity 0.25s;
+    gap: 0.85rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
 
   .card:hover {
     border-color: var(--border2);
-    transform: translateY(-3px);
-    box-shadow: 0 20px 60px rgba(0,0,0,0.4), 0 0 0 1px rgba(124,106,255,0.1);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 30px rgba(0,0,0,0.08);
   }
-
-  .card:hover::before { opacity: 1; }
 
   .card.featured {
-    border-color: rgba(124,106,255,0.3);
-    background: linear-gradient(135deg, var(--surface) 0%, rgba(124,106,255,0.05) 100%);
+    border-color: rgba(0,122,255,0.25);
   }
 
-  .card.featured::before { opacity: 0.5; }
+  .card.featured:hover {
+    border-color: rgba(0,122,255,0.4);
+    box-shadow: 0 8px 30px rgba(0,122,255,0.08);
+  }
 
   .card-header {
     display: flex;
@@ -350,57 +345,58 @@
   }
 
   .card-icon {
-    width: 48px; height: 48px;
+    width: 46px; height: 46px;
     border-radius: 12px;
-    border: 1px solid var(--border2);
+    border: 1px solid var(--border);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.5rem;
+    font-size: 1.4rem;
     flex-shrink: 0;
+    background: var(--surface);
   }
 
   .card-badges {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    gap: 6px;
+    gap: 5px;
   }
 
   .badge {
-    font-family: 'Space Mono', monospace;
-    font-size: 0.6rem;
-    padding: 3px 8px;
-    border-radius: 4px;
-    letter-spacing: 0.08em;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.58rem;
+    padding: 2px 7px;
+    border-radius: 5px;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
-    font-weight: 700;
+    font-weight: 500;
   }
 
-  .badge-featured { background: rgba(124,106,255,0.2); color: var(--accent3); border: 1px solid rgba(124,106,255,0.3); }
-  .badge-free { background: rgba(74,222,128,0.15); color: var(--green); border: 1px solid rgba(74,222,128,0.25); }
-  .badge-macos { background: rgba(34,211,238,0.12); color: var(--cyan); border: 1px solid rgba(34,211,238,0.2); }
-  .badge-win { background: rgba(251,146,60,0.12); color: var(--orange); border: 1px solid rgba(251,146,60,0.2); }
-  .badge-community { background: rgba(244,114,182,0.12); color: var(--pink); border: 1px solid rgba(244,114,182,0.2); }
-  .badge-new { background: rgba(251,146,60,0.2); color: var(--orange); border: 1px solid rgba(251,146,60,0.3); }
+  .badge-featured { background: rgba(0,122,255,0.08); color: var(--accent); border: 1px solid rgba(0,122,255,0.2); }
+  .badge-free { background: rgba(5,150,105,0.08); color: var(--green); border: 1px solid rgba(5,150,105,0.2); }
+  .badge-macos { background: rgba(37,99,235,0.08); color: var(--cyan); border: 1px solid rgba(37,99,235,0.15); }
+  .badge-win { background: rgba(217,119,6,0.08); color: var(--orange); border: 1px solid rgba(217,119,6,0.15); }
+  .badge-community { background: rgba(219,39,119,0.08); color: var(--pink); border: 1px solid rgba(219,39,119,0.15); }
+  .badge-new { background: rgba(217,119,6,0.1); color: var(--orange); border: 1px solid rgba(217,119,6,0.2); }
 
   .card-name {
-    font-size: 1.15rem;
-    font-weight: 700;
+    font-size: 1.05rem;
+    font-weight: 600;
     letter-spacing: -0.01em;
     color: var(--text);
     margin-bottom: 2px;
   }
 
   .card-author {
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.65rem;
     color: var(--text3);
-    letter-spacing: 0.05em;
+    letter-spacing: 0.03em;
   }
 
   .card-author a {
-    color: var(--accent3);
+    color: var(--accent);
     text-decoration: none;
   }
 
@@ -413,18 +409,18 @@
   .card-tools {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.4rem;
+    gap: 0.35rem;
   }
 
   .tool-pill {
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.6rem;
-    color: var(--text3);
+    color: var(--text2);
     border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 3px 8px;
+    border-radius: 5px;
+    padding: 2px 7px;
     background: var(--surface2);
-    letter-spacing: 0.03em;
+    letter-spacing: 0.02em;
   }
 
   .card-footer {
@@ -432,7 +428,7 @@
     align-items: center;
     justify-content: space-between;
     margin-top: auto;
-    padding-top: 1rem;
+    padding-top: 0.85rem;
     border-top: 1px solid var(--border);
   }
 
@@ -445,9 +441,9 @@
   .meta-item {
     display: flex;
     align-items: center;
-    gap: 5px;
-    font-family: 'Space Mono', monospace;
-    font-size: 0.65rem;
+    gap: 4px;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.62rem;
     color: var(--text3);
   }
 
@@ -456,30 +452,30 @@
   .install-btn {
     display: inline-flex;
     align-items: center;
-    gap: 7px;
-    background: var(--accent);
+    gap: 6px;
+    background: var(--text);
     color: white;
     border: none;
-    border-radius: 7px;
-    padding: 9px 16px;
-    font-family: 'Space Mono', monospace;
+    border-radius: 10px;
+    padding: 8px 16px;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    font-weight: 500;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
     cursor: pointer;
     text-decoration: none;
-    transition: background 0.2s, transform 0.1s;
+    transition: opacity 0.2s, transform 0.1s;
   }
 
-  .install-btn:hover { background: var(--accent2); transform: scale(1.02); }
+  .install-btn:hover { opacity: 0.8; transform: scale(1.02); }
   .install-btn:active { transform: scale(0.98); }
 
   .install-btn svg { width: 13px; height: 13px; }
 
   /* ── COMING SOON CARD ── */
   .card.coming-soon {
-    opacity: 0.5;
+    opacity: 0.45;
     pointer-events: none;
   }
 
@@ -490,12 +486,12 @@
 
   /* ── SECTION HEADING ── */
   .section-label {
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.65rem;
     color: var(--text3);
-    letter-spacing: 0.15em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.25rem;
     padding-bottom: 0.75rem;
     border-bottom: 1px solid var(--border);
     display: flex;
@@ -503,39 +499,30 @@
     justify-content: space-between;
   }
 
-  .section-label span { color: var(--accent3); }
+  .section-label span { color: var(--accent); }
 
   /* ── SUBMIT CTA ── */
   .submit-cta {
     position: relative;
     z-index: 1;
-    margin: 0 2rem 6rem;
+    margin: 0 2rem 4rem;
     max-width: 1200px;
     margin-left: auto;
     margin-right: auto;
     background: var(--surface);
-    border: 1px solid var(--border2);
-    border-radius: 16px;
-    padding: 3rem;
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 2.5rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 2rem;
-    overflow: hidden;
-  }
-
-  .submit-cta::before {
-    content: '';
-    position: absolute;
-    top: -60px; right: -60px;
-    width: 240px; height: 240px;
-    background: radial-gradient(circle, rgba(124,106,255,0.15), transparent 70%);
-    pointer-events: none;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
 
   .submit-cta h2 {
-    font-size: 1.6rem;
-    font-weight: 800;
+    font-size: 1.4rem;
+    font-weight: 700;
     letter-spacing: -0.02em;
     margin-bottom: 0.5rem;
   }
@@ -550,23 +537,23 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    background: transparent;
-    color: var(--accent3);
-    border: 1px solid var(--accent);
-    border-radius: 8px;
+    background: var(--text);
+    color: white;
+    border: none;
+    border-radius: 10px;
     padding: 12px 24px;
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
+    font-weight: 500;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
     text-decoration: none;
     white-space: nowrap;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: opacity 0.2s;
   }
 
-  .submit-btn:hover { background: rgba(124,106,255,0.1); color: white; }
+  .submit-btn:hover { opacity: 0.8; }
 
   /* ── FOOTER ── */
   footer {
@@ -578,20 +565,21 @@
   }
 
   footer p {
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.65rem;
     color: var(--text3);
-    letter-spacing: 0.05em;
+    letter-spacing: 0.03em;
   }
 
-  footer a { color: var(--accent3); text-decoration: none; }
+  footer a { color: var(--accent); text-decoration: none; }
 
   /* ── MODAL ── */
   .modal-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0,0,0,0.7);
+    background: rgba(0,0,0,0.3);
     backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
     z-index: 200;
     display: flex;
     align-items: center;
@@ -609,8 +597,8 @@
 
   .modal {
     background: var(--surface);
-    border: 1px solid var(--border2);
-    border-radius: 16px;
+    border: 1px solid var(--border);
+    border-radius: 20px;
     padding: 2rem;
     max-width: 640px;
     width: 100%;
@@ -619,6 +607,7 @@
     transform: translateY(20px);
     transition: transform 0.2s;
     position: relative;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.12);
   }
 
   .modal-overlay.open .modal { transform: translateY(0); }
@@ -628,8 +617,8 @@
     top: 1rem; right: 1rem;
     background: var(--surface2);
     border: 1px solid var(--border);
-    border-radius: 6px;
-    color: var(--text2);
+    border-radius: 8px;
+    color: var(--text3);
     font-size: 1rem;
     width: 32px; height: 32px;
     display: flex; align-items: center; justify-content: center;
@@ -643,12 +632,12 @@
     display: flex;
     align-items: center;
     gap: 1rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1.25rem;
   }
 
   .modal h2 {
-    font-size: 1.4rem;
-    font-weight: 800;
+    font-size: 1.3rem;
+    font-weight: 700;
     letter-spacing: -0.01em;
   }
 
@@ -662,16 +651,16 @@
   .install-steps {
     background: var(--bg);
     border: 1px solid var(--border);
-    border-radius: 10px;
+    border-radius: 14px;
     padding: 1.25rem;
     margin-bottom: 1.5rem;
   }
 
   .install-steps h3 {
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.65rem;
     color: var(--text3);
-    letter-spacing: 0.1em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
     margin-bottom: 1rem;
   }
@@ -688,11 +677,11 @@
   .step-num {
     width: 22px; height: 22px;
     border-radius: 50%;
-    background: var(--accent);
+    background: var(--text);
     color: white;
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.65rem;
-    font-weight: 700;
+    font-weight: 500;
     display: flex; align-items: center; justify-content: center;
     flex-shrink: 0;
     margin-top: 1px;
@@ -704,22 +693,23 @@
 
   .step-title {
     font-size: 0.85rem;
-    font-weight: 700;
+    font-weight: 600;
     margin-bottom: 4px;
   }
 
   .step-code {
-    font-family: 'Space Mono', monospace;
-    font-size: 0.72rem;
-    background: var(--surface2);
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.75rem;
+    background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 5px;
+    border-radius: 8px;
     padding: 8px 10px;
-    color: var(--cyan);
+    color: var(--text);
     overflow-x: auto;
     white-space: pre;
     cursor: pointer;
     transition: border-color 0.2s;
+    line-height: 1.7;
   }
 
   .step-code:hover { border-color: var(--accent); }
@@ -733,7 +723,7 @@
 
   .modal-actions {
     display: flex;
-    gap: 1rem;
+    gap: 0.75rem;
     flex-wrap: wrap;
   }
 
@@ -742,11 +732,11 @@
     align-items: center;
     gap: 7px;
     padding: 10px 18px;
-    border-radius: 7px;
-    font-family: 'Space Mono', monospace;
+    border-radius: 10px;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    font-weight: 500;
+    letter-spacing: 0.04em;
     text-transform: uppercase;
     text-decoration: none;
     cursor: pointer;
@@ -754,8 +744,8 @@
     border: none;
   }
 
-  .modal-btn-primary { background: var(--accent); color: white; }
-  .modal-btn-primary:hover { background: var(--accent2); }
+  .modal-btn-primary { background: var(--text); color: white; }
+  .modal-btn-primary:hover { opacity: 0.8; }
 
   .modal-btn-secondary { background: var(--surface2); color: var(--text2); border: 1px solid var(--border); }
   .modal-btn-secondary:hover { color: var(--text); border-color: var(--border2); }
@@ -766,13 +756,13 @@
     bottom: 2rem;
     left: 50%;
     transform: translateX(-50%) translateY(10px);
-    background: var(--surface);
-    border: 1px solid var(--border2);
-    border-radius: 8px;
+    background: var(--text);
+    border: none;
+    border-radius: 10px;
     padding: 10px 18px;
-    font-family: 'Space Mono', monospace;
+    font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.7rem;
-    color: var(--green);
+    color: white;
     z-index: 300;
     opacity: 0;
     transition: all 0.2s;
@@ -785,7 +775,7 @@
   }
 
   @media (max-width: 600px) {
-    .hero h1 { font-size: 2.4rem; }
+    .hero h1 { font-size: 2.2rem; }
     .submit-cta { flex-direction: column; }
     .hero-stats { gap: 1.5rem; }
     .stat-divider { display: none; }
@@ -799,14 +789,15 @@
 
 <!-- NAV -->
 <nav>
-  <a href="#" class="nav-logo">
-    VoiceOS <span class="badge">Integrations</span>
+  <a href="https://voiceos.com" class="nav-logo">
+    <img src="https://www.voiceos.com/_next/image?url=%2FVoiceOSFullLogo.png&w=640&q=90" alt="VoiceOS">
+    <span class="badge">Integrations</span>
   </a>
   <ul class="nav-links">
     <li><a href="#marketplace">Browse</a></li>
     <li><a href="#submit">Submit</a></li>
-    <li><a href="https://voiceos.com" target="_blank">VoiceOS ↗</a></li>
-    <li><a href="https://github.com/gabeperez" target="_blank" class="nav-cta">GitHub ↗</a></li>
+    <li><a href="https://voiceos.com" target="_blank">VoiceOS</a></li>
+    <li><a href="https://github.com/gabeperez" target="_blank" class="nav-cta">GitHub</a></li>
   </ul>
 </nav>
 
@@ -814,8 +805,9 @@
 <section class="hero">
   <div class="hero-tag">
     <span class="dot"></span>
-    Community Marketplace · Open Source
+    Community Marketplace
   </div>
+  <img src="https://www.voiceos.com/_next/image?url=%2FVoiceOSFullLogo.png&w=640&q=90" alt="VoiceOS" class="hero-logo">
   <h1>Extend <span>VoiceOS</span><br>with any integration</h1>
   <p>Browse, install, and share MCP-powered integrations that give VoiceOS new superpowers. From app control to AI agents — all voice-activated.</p>
   <div class="hero-stats">
@@ -866,7 +858,7 @@
     <div class="card featured" data-tags="macOS,productivity" onclick="openModal('launcher')">
       <div class="card-header">
         <div>
-          <div class="card-icon" style="background: linear-gradient(135deg, #1e1e2e, #16162a);">🚀</div>
+          <div class="card-icon" style="background: linear-gradient(135deg, #f0f4ff, #e8ecf4);">🚀</div>
         </div>
         <div class="card-badges">
           <span class="badge badge-featured">Featured</span>
@@ -878,7 +870,7 @@
         <div class="card-name">macOS App Launcher</div>
         <div class="card-author">by <a href="https://github.com/gabeperez" onclick="e => e.stopPropagation()">@gabeperez</a></div>
       </div>
-      <div class="card-desc">Open, focus, quit apps and set volume by voice. Uses native <code style="color:var(--cyan);font-family:Space Mono,monospace;font-size:0.8em">open -a</code> and <code style="color:var(--cyan);font-family:Space Mono,monospace;font-size:0.8em">osascript</code> — much faster than alternatives. Say "Open Chrome" or "Set volume to 40."</div>
+      <div class="card-desc">Open, focus, quit apps and set volume by voice. Uses native <code style="color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82em;background:rgba(0,122,255,0.06);padding:1px 5px;border-radius:4px;">open -a</code> and <code style="color:var(--accent);font-family:'DM Mono',monospace;font-size:0.82em;background:rgba(0,122,255,0.06);padding:1px 5px;border-radius:4px;">osascript</code> — much faster than alternatives. Say "Open Chrome" or "Set volume to 40."</div>
       <div class="card-tools">
         <span class="tool-pill">open_app</span>
         <span class="tool-pill">focus_app</span>
@@ -910,7 +902,7 @@
     <div class="card featured" data-tags="ai,productivity,macOS,windows" onclick="openModal('poke')">
       <div class="card-header">
         <div>
-          <div class="card-icon" style="background: linear-gradient(135deg, #0f1e15, #0a1a1f);">🌴</div>
+          <div class="card-icon" style="background: linear-gradient(135deg, #ecfdf5, #e0f7ed);">🌴</div>
         </div>
         <div class="card-badges">
           <span class="badge badge-featured">Featured</span>
@@ -941,7 +933,7 @@
           </span>
           <span class="meta-item">TypeScript</span>
         </div>
-        <button class="install-btn" onclick="event.stopPropagation(); openModal('poke')" style="background: var(--green); color: #0a0a0f;">
+        <button class="install-btn" onclick="event.stopPropagation(); openModal('poke')">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Install
         </button>
@@ -953,7 +945,7 @@
       <div class="card-header">
         <div class="card-icon" style="background: var(--surface2);">🎵</div>
         <div class="card-badges">
-          <span class="badge" style="background:var(--surface2);color:var(--text3);border-color:var(--border);">Coming Soon</span>
+          <span class="badge" style="background:var(--surface2);color:var(--text3);border:1px solid var(--border);">Coming Soon</span>
         </div>
       </div>
       <div>
@@ -974,8 +966,8 @@
 
   </div>
 
-  <div id="no-results" style="display:none; text-align:center; padding:4rem 0; color:var(--text3); font-family:'Space Mono',monospace; font-size:0.8rem;">
-    No integrations found. <a href="#submit" style="color:var(--accent3);">Build one?</a>
+  <div id="no-results" style="display:none; text-align:center; padding:4rem 0; color:var(--text3); font-family:'DM Mono',monospace; font-size:0.8rem;">
+    No integrations found. <a href="#submit" style="color:var(--accent);">Build one?</a>
   </div>
 </section>
 
@@ -993,7 +985,7 @@
 
 <!-- FOOTER -->
 <footer>
-  <p>VoiceOS Integrations Marketplace · Built with ♥ by the community · <a href="https://github.com/gabeperez" target="_blank">GitHub</a> · Not affiliated with VoiceOS officially</p>
+  <p>VoiceOS Integrations Marketplace · Built with care by the community · <a href="https://github.com/gabeperez" target="_blank">GitHub</a> · <a href="https://voiceos.com" target="_blank">voiceos.com</a></p>
 </footer>
 
 <!-- MODALS -->
@@ -1002,7 +994,7 @@
 </div>
 
 <!-- TOAST -->
-<div class="toast" id="toast">✓ Copied to clipboard</div>
+<div class="toast" id="toast">Copied to clipboard</div>
 
 <script>
 const integrations = {
@@ -1049,7 +1041,7 @@ function openModal(id) {
       <div class="step-content">
         <div class="step-title">${s.title}</div>
         <div class="step-code" onclick="copyCode(this)">${escapeHtml(s.code)}</div>
-        ${s.note ? `<div class="step-note">💡 ${s.note}</div>` : ''}
+        ${s.note ? `<div class="step-note">${s.note}</div>` : ''}
       </div>
     </div>
   `).join('');
@@ -1057,7 +1049,7 @@ function openModal(id) {
   document.getElementById('modal-content').innerHTML = `
     <button class="modal-close" onclick="closeModal()">✕</button>
     <div class="modal-header">
-      <div class="card-icon" style="width:52px;height:52px;border-radius:14px;border:1px solid var(--border2);display:flex;align-items:center;justify-content:center;font-size:1.6rem;">${data.icon}</div>
+      <div class="card-icon" style="width:48px;height:48px;border-radius:14px;border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-size:1.5rem;background:var(--surface);">${data.icon}</div>
       <div>
         <h2>${data.name}</h2>
         <div class="card-author">by <a href="${data.authorUrl}" target="_blank">${data.author}</a> · ${data.requirements}</div>
@@ -1098,7 +1090,7 @@ document.addEventListener('keydown', e => {
 
 function copyCode(el) {
   const text = el.textContent;
-  navigator.clipboard.writeText(text).then(() => showToast('✓ Copied to clipboard'));
+  navigator.clipboard.writeText(text).then(() => showToast('Copied to clipboard'));
 }
 
 function showToast(msg) {
@@ -1160,10 +1152,10 @@ window.addEventListener('load', () => {
   // Staggered card entrance
   document.querySelectorAll('.card').forEach((c, i) => {
     c.style.opacity = '0';
-    c.style.transform = 'translateY(20px)';
-    c.style.transition = 'opacity 0.4s ease, transform 0.4s ease, border-color 0.25s, box-shadow 0.25s';
+    c.style.transform = 'translateY(12px)';
+    c.style.transition = 'opacity 0.4s ease, transform 0.4s ease, border-color 0.2s, box-shadow 0.2s';
     setTimeout(() => {
-      c.style.opacity = c.classList.contains('coming-soon') ? '0.5' : '1';
+      c.style.opacity = c.classList.contains('coming-soon') ? '0.45' : '1';
       c.style.transform = 'translateY(0)';
     }, 100 + i * 80);
   });


### PR DESCRIPTION
## Summary
- Switches from dark theme to light theme matching voiceos.com's design system
- Replaces Syne + Space Mono fonts with system font stack + DM Mono (same as voiceos.com)
- Updates color palette: #F9F9F9 background, #0a0a0a text, #007AFF accent blue, subtle borders/shadows
- Adds official VoiceOS logos (nav, hero, favicon) using brand assets

## Test plan
- [ ] Verify page renders correctly in light theme
- [ ] Check nav logo and hero logo load from voiceos.com CDN
- [ ] Test card hover states, modal open/close, copy-to-clipboard
- [ ] Verify mobile responsive layout at 600px breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)